### PR TITLE
Use Gson as default provider/mapper in JsonPath configuration

### DIFF
--- a/restful-api-client/src/main/java/io/testproject/addon/restfulapiclient/internal/RequestHelper.java
+++ b/restful-api-client/src/main/java/io/testproject/addon/restfulapiclient/internal/RequestHelper.java
@@ -17,8 +17,15 @@
 package io.testproject.addon.restfulapiclient.internal;
 
 import com.google.common.base.Strings;
+import com.google.gson.GsonBuilder;
+import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.GsonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
 import io.testproject.java.sdk.v2.exceptions.FailureException;
 import org.apache.http.client.utils.URIBuilder;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
@@ -31,6 +38,8 @@ import java.net.URISyntaxException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
+import java.util.EnumSet;
+import java.util.Set;
 import javax.ws.rs.core.MediaType;
 
 /**
@@ -40,6 +49,27 @@ import javax.ws.rs.core.MediaType;
  * @version 1.0
  */
 public class RequestHelper {
+
+    static {
+        // Use Gson as default provider/mapper for JsonPath parsing.
+        // This will ensure that result is always a valid json
+        Configuration.setDefaults(new Configuration.Defaults() {
+            private final JsonProvider jsonProvider = new GsonJsonProvider(new GsonBuilder().serializeNulls().create());
+            private final MappingProvider mappingProvider = new GsonMappingProvider();
+
+            public JsonProvider jsonProvider() {
+                return jsonProvider;
+            }
+
+            public MappingProvider mappingProvider() {
+                return mappingProvider;
+            }
+
+            public Set<Option> options() {
+                return EnumSet.noneOf(Option.class);
+            }
+        });
+    }
 
     private RequestMethod requestMethod;
 


### PR DESCRIPTION
This will ensure that the restful api result is always a valid json