### PR TITLE
Added output parameter for the response time of the request in the RESTful API client addon

### DIFF
--- a/restful-api-client/src/main/java/io/testproject/addon/restfulapiclient/actions/base/BaseAction.java
+++ b/restful-api-client/src/main/java/io/testproject/addon/restfulapiclient/actions/base/BaseAction.java
@@ -59,6 +59,9 @@ public class BaseAction {
     @Parameter(description = "Response Headers", direction = ParameterDirection.OUTPUT)
     public String responseHeaders;
 
+    @Parameter(description = "Response time of the request (in milliseconds)", direction = ParameterDirection.OUTPUT)
+    public long responseTime;
+
     @Parameter(description = "The path to the Json Schema")
     public String schemaPath;
 
@@ -97,6 +100,7 @@ public class BaseAction {
         // Send the request and receive a response
         ServerResponse serverResponse = requestHelper.sendRequest();
         status = serverResponse.responseCode;
+        responseTime = serverResponse.responseTime;
 
         // If user provided jsonPath parameter then set response to be the value  found by evaluating jsonPath
         if(!jsonPath.isEmpty()) {

--- a/restful-api-client/src/main/java/io/testproject/addon/restfulapiclient/internal/RequestHelper.java
+++ b/restful-api-client/src/main/java/io/testproject/addon/restfulapiclient/internal/RequestHelper.java
@@ -24,6 +24,7 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.spi.json.GsonJsonProvider;
 import io.testproject.java.sdk.v2.exceptions.FailureException;
+import org.apache.commons.lang3.time.StopWatch;
 import org.apache.http.client.utils.URIBuilder;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
@@ -47,6 +48,7 @@ import java.net.URISyntaxException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Helper class for sending the requests
@@ -238,8 +240,10 @@ public class RequestHelper {
         }
 
         Response response = null;
+        StopWatch watch = new StopWatch();
 
         try {
+            watch.start();
             switch (requestMethod) {
                 case GET:
                     response = request.method("GET", entity);
@@ -259,9 +263,12 @@ public class RequestHelper {
         } catch (ProcessingException e) {
             throw new FailureException("Failed to send the request due to an error\n" + e.toString(), e);
         }
+        finally {
+            watch.stop();
+        }
 
         ServerResponse sr = new ServerResponse();
-
+        sr.responseTime = watch.getTime(TimeUnit.MILLISECONDS);
         sr.responseBody = response.readEntity(String.class);
         sr.responseCode = response.getStatus();
         sr.responseHeaders = buildResponseString(response.getStringHeaders());

--- a/restful-api-client/src/main/java/io/testproject/addon/restfulapiclient/internal/ServerResponse.java
+++ b/restful-api-client/src/main/java/io/testproject/addon/restfulapiclient/internal/ServerResponse.java
@@ -28,6 +28,7 @@ public class ServerResponse {
     public String responseBody = "";
     public int responseCode;
     public String responseHeaders;
+    public long responseTime;
 
     public String jsonParseResult = null;
     public String jsonParseResultAsJson = null;


### PR DESCRIPTION
Users can now get the time it took for a response to complete as an output parameter. 

Signed-off-by: Artem Kuznetsov <artem.kuznetsov@testproject.io>