### PR TITLE
support search fields in iOS example addon

### DIFF
--- a/Examples/IOS/src/main/java/io/testproject/examples/sdk/actions/ClearFieldsAction.java
+++ b/Examples/IOS/src/main/java/io/testproject/examples/sdk/actions/ClearFieldsAction.java
@@ -20,6 +20,10 @@ public class ClearFieldsAction implements IOSAction {
             element.clear();
         }
 
+        for (IOSElement element : helper.getDriver().findElements(By.className("XCUIElementTypeSearchField"))) {
+            element.clear();
+        }
+
         return ExecutionResult.PASSED;
     }
 }


### PR DESCRIPTION
Several users are using the example addons as helpful actions. to help these users, we should support more types of text fields like search fields.